### PR TITLE
Deck search: always reveal full deck in a two-zone picker (selectable…

### DIFF
--- a/battle_simulator_v2/core/effects/context.js
+++ b/battle_simulator_v2/core/effects/context.js
@@ -107,12 +107,27 @@ export class EffectContext {
    * カードを1枚選ぶ。optional なら「選ばない」も可（null が返る）。
    * cards: 選択可能なカード / displayCards: 選択不可だが見せるカード
    *   （「デッキの上からN枚を見る」で対象外のカードも公開するために使う）
+   *
+   * デッキサーチ（候補が ctx.deckCards(...) 由来＝デッキ内のカード）の場合は、
+   * 対象の有無にかかわらずデッキ全体を「確認用（選択不可）」として見せる。
+   * deckSearch:true を明示してもよい。確認したら効果完了時に必ずシャッフルされる
+   * （_deckViewedNeedsShuffle フラグ→engine._runEffect で flush。ctx.shuffleDeck() で明示シャッフル済みなら二重シャッフルしない）。
    */
-  chooseCard({ cards, title, optional = false, skipLabel = '選ばない', displayCards = [] }) {
+  chooseCard({ cards, title, optional = false, skipLabel = '選ばない', displayCards = [], deckSearch = undefined }) {
+    const deck = this.player.deck;
+    // デッキサーチ判定: 明示指定 / deckCards(...) のタグ付き配列 / 候補が全てデッキ内
+    const isDeckSearch = deckSearch === true
+      || (cards && cards._fromDeck === true)
+      || (cards.length > 0 && cards.every((c) => deck.includes(c)));
+    if (isDeckSearch && displayCards.length === 0) {
+      displayCards = [...deck]; // デッキ全体を確認用に見せる（対象が無くても確認できる）
+      this.player._deckViewedNeedsShuffle = true; // 確認後のシャッフルを保証する
+    }
     return {
       kind: 'chooseCard',
       player: this.playerIdx,
       title,
+      deckSearch: isDeckSearch,
       displayCards: displayCards.filter((c) => !cards.includes(c)),
       buildOptions: () => [
         ...cards.map((c, i) => ({ id: `card_${i}`, label: c.name, card: c, value: c })),
@@ -412,6 +427,7 @@ export class EffectContext {
   /** デッキをシャッフルする (5.6) */
   shuffleDeck() {
     this.engine._shuffle(this.player.deck);
+    this.player._deckViewedNeedsShuffle = false; // 明示シャッフルでサーチ後シャッフル保証を満たす（二重シャッフル防止）
     this.log(`${this.player.name}: デッキをシャッフル`);
   }
 
@@ -420,9 +436,12 @@ export class EffectContext {
     this.log(`${this.player.name}: エールデッキをシャッフル`);
   }
 
-  /** デッキ内の条件一致カード一覧（非公開領域なので「見つからない」選択も保証される） */
+  /** デッキ内の条件一致カード一覧（非公開領域なので「見つからない」選択も保証される）。
+   *  戻り配列に _fromDeck タグを付け、chooseCard がデッキサーチと判定できるようにする（デッキ全体を確認枠に表示）。 */
   deckCards(filter) {
-    return this.player.deck.filter(filter);
+    const arr = this.player.deck.filter(filter);
+    Object.defineProperty(arr, '_fromDeck', { value: true, enumerable: false });
+    return arr;
   }
 
   /** デッキから特定カードを取り除く（移動前処理） */

--- a/battle_simulator_v2/core/engine.js
+++ b/battle_simulator_v2/core/engine.js
@@ -260,8 +260,20 @@ export class Engine {
    * 選択後に再開する。完了したら after() を呼ぶ。
    */
   _runEffect(effectDef, ctxOpts, after) {
-    if (!effectDef?.run) {
+    // 効果完了時に「デッキサーチで確認したのに未シャッフル」のデッキを必ずシャッフルする（確認後シャッフル保証）。
+    // ctx.shuffleDeck() を明示的に呼んだ場合は _deckViewedNeedsShuffle が false になっているため二重シャッフルしない。
+    const done = () => {
+      for (const p of this.state.players) {
+        if (p._deckViewedNeedsShuffle) {
+          p._deckViewedNeedsShuffle = false;
+          this._shuffle(p.deck);
+          this.log(`${p.name}: デッキをシャッフル（サーチ確認後）`);
+        }
+      }
       after();
+    };
+    if (!effectDef?.run) {
+      done();
       return;
     }
     // ctxOpts.ctx で外から ctx を渡せる（アーツのボーナス蓄積を受け取るため等）
@@ -271,10 +283,10 @@ export class Engine {
       gen = effectDef.run(ctx);
     } catch (e) {
       this.log(`⚠️ 効果の開始に失敗: ${e.message}`);
-      after();
+      done();
       return;
     }
-    this._stepEffect(gen, undefined, after);
+    this._stepEffect(gen, undefined, done);
   }
 
   _stepEffect(gen, input, after) {
@@ -293,13 +305,17 @@ export class Engine {
     }
     const request = r.value; // EffectContext.chooseXxx() が返す選択要求
     const options = request.buildOptions();
-    if (options.length === 0 || (options.length === 1 && options[0].id === 'skip')) {
+    // デッキサーチで確認枠がある場合は、対象が無くても（skipのみ）デッキを見せるためモーダルを表示する
+    const showDeckView = request.deckSearch && (request.displayCards || []).length > 0;
+    const onlySkip = options.length === 1 && options[0].id === 'skip';
+    if (options.length === 0 || (onlySkip && !showDeckView)) {
       // 選択肢なし（または「選ばない」のみ）→ null で再開
       this._stepEffect(gen, null, after);
       return;
     }
-    // 強制のカード選択で候補が1枚だけなら自動で確定（確定クリックの手間を省く）
-    if (request.kind === 'chooseCard' && options.length === 1 && options[0].card) {
+    // 強制のカード選択で候補が1枚だけなら自動で確定（確定クリックの手間を省く）。
+    // ただしデッキサーチ（確認枠あり）は、デッキ全体を確認させるため自動確定しない。
+    if (request.kind === 'chooseCard' && options.length === 1 && options[0].card && !showDeckView) {
       this._stepEffect(gen, options[0].value, after);
       return;
     }

--- a/battle_simulator_v2/tests/test.js
+++ b/battle_simulator_v2/tests/test.js
@@ -885,6 +885,44 @@ export async function runTests() {
     assertEq(oppCenter.damage, before + 20, '[ターンに1回]を超えて反撃している');
   });
 
+  await testAsync('デッキサーチ: 対象の有無に関わらずデッキ全体を確認でき、確認後シャッフルされる', async () => {
+    const e = await setupMainStep(deckMap, 132);
+    const p0 = e.state.players[0];
+    const deckLen = p0.deck.length;
+
+    // (1) 候補ありのサーチ: deckSearch フラグ + デッキ全体が「選択枠 + 確認枠」に分かれて出る
+    let done1 = false;
+    const eff1 = { *run(ctx) {
+      const cand = ctx.deckCards((c) => c.kind === 'holomen');
+      yield ctx.chooseCard({ cards: cand, title: 'test1', optional: true });
+    } };
+    e._runEffect(eff1, { playerIdx: 0 }, () => { done1 = true; });
+    let req = e.state.pending && e.state.pending.request;
+    assert(req && req.deckSearch === true, 'deckSearch フラグが立っていない');
+    const selCount = e.state.pending.options.filter((o) => o.card).length;
+    assert(selCount > 0, '選択候補(ホロメン)が無い前提が崩れている');
+    assertEq(selCount + req.displayCards.length, deckLen, '選択枠+確認枠がデッキ全体に一致しない');
+    // skip で解決 → 確認後シャッフル保証フラグが flush される
+    e.apply(e.state.pending.options.find((o) => o.id === 'skip').id);
+    let guard = 0;
+    while (!done1 && e.state.pending && guard++ < 10) e.apply(e.state.pending.options[0].id);
+    assert(done1, '(1)完了しない');
+    assert(!p0._deckViewedNeedsShuffle, '確認後シャッフル保証フラグが残っている(flushされていない)');
+
+    // (2) 候補0のサーチ: 自動スキップされず、デッキ確認モーダルが出る
+    let done2 = false;
+    const eff2 = { *run(ctx) {
+      const cand = ctx.deckCards((c) => c.name === '___存在しないカード名___');
+      yield ctx.chooseCard({ cards: cand, title: 'test2', optional: true, skipLabel: '見つからなかったことにする' });
+    } };
+    e._runEffect(eff2, { playerIdx: 0 }, () => { done2 = true; });
+    assert(e.state.pending && e.state.pending.request.deckSearch, '候補0でモーダルが出ていない(自動スキップされた)');
+    assert((e.state.pending.request.displayCards || []).length > 0, '候補0でもデッキ確認枠があるべき');
+    assert(!done2, '候補0で即完了してしまっている(モーダルが出ていない)');
+    e.apply(e.state.pending.options.find((o) => o.id === 'skip').id);
+    assert(done2, '(2)完了しない');
+  });
+
   await testAsync('コンパイラ: 全カードでクラッシュせず、一定数を自動実装できる', async () => {
     let compiled = 0;
     let slots = 0;

--- a/battle_simulator_v2/ui/app.js
+++ b/battle_simulator_v2/ui/app.js
@@ -810,6 +810,10 @@ function renderEffectChoiceModal(s) {
   });
 
   const hasCards = s.pending.options.some((o) => o.card);
+  const displayCards = s.pending.request.displayCards || [];
+  const isDeckSearch = !!s.pending.request.deckSearch;
+
+  // --- 上段: 選択可能なカード枠（カード以外の選択肢はフッターのボタンへ） ---
   for (const opt of s.pending.options) {
     if (opt.card) {
       const c = document.createElement('div');
@@ -830,13 +834,29 @@ function renderEffectChoiceModal(s) {
     }
   }
   if (hasCards) footer.appendChild(confirmBtn);
+  // デッキサーチで選べる対象が無い場合の注記（デッキ確認のみ）
+  if (isDeckSearch && !hasCards) {
+    const note = document.createElement('div');
+    note.style.cssText = 'grid-column:1/-1;color:#889;padding:6px 0;';
+    note.textContent = '選択できる対象はありません（デッキを確認できます）';
+    grid.appendChild(note);
+  }
 
-  // 選択対象外だが公開されているカード（「上からN枚見る」の残り等）はグレー表示
-  for (const card of s.pending.request.displayCards || []) {
-    const c = document.createElement('div');
-    c.className = 'archive-grid-card display-only';
-    c.innerHTML = `<img src="${card.imageUrl || ''}" alt="${escapeText(card.name)}" loading="lazy"><div>${escapeText(card.name)}（対象外）</div>`;
-    grid.appendChild(c);
+  // --- 下段: 確認用（選択不可）カード枠。デッキサーチはデッキ全体、その他は「対象外」公開カード ---
+  if (displayCards.length) {
+    const divider = document.createElement('div');
+    divider.className = 'choice-divider';
+    divider.style.cssText = 'grid-column:1/-1;margin:10px 0 4px;padding-top:8px;border-top:1px dashed #556;color:#aab;font-size:0.85em;text-align:center;';
+    divider.textContent = isDeckSearch
+      ? '― デッキ内（確認用・選択不可 / 確認後シャッフルされます）―'
+      : '― 対象外（確認用）―';
+    grid.appendChild(divider);
+    for (const card of displayCards) {
+      const c = document.createElement('div');
+      c.className = 'archive-grid-card display-only';
+      c.innerHTML = `<img src="${card.imageUrl || ''}" alt="${escapeText(card.name)}" loading="lazy"><div>${escapeText(card.name)}</div>`;
+      grid.appendChild(c);
+    }
   }
 }
 


### PR DESCRIPTION
… / view-only) regardless of matches, and guarantee shuffle after viewing; works for all 192 deckCards()-based cards + compiler with no card edits; 55/55 tests pass