### PR TITLE
Add "任意効果の発動確認" setting (ON/OFF) gating optional-effect activation co…

### DIFF
--- a/battle_simulator_v2.html
+++ b/battle_simulator_v2.html
@@ -59,6 +59,14 @@
           </div>
         </div>
         <div class="settings-section">
+          <div class="settings-label">任意効果の発動確認</div>
+          <div class="settings-row" id="confirm-optional-buttons">
+            <button data-confirm-optional="on">確認する</button>
+            <button data-confirm-optional="off">自動で発動</button>
+          </div>
+          <div class="settings-note">強制でない効果（「〜できる」等）を発動するか毎回確認します</div>
+        </div>
+        <div class="settings-section">
           <button id="copy-log-button" class="settings-action">📋 ログをコピー</button>
           <button id="concede-p1-button" class="settings-action">🏳 プレイヤー1が投了</button>
           <button id="concede-p2-button" class="settings-action">🏳 プレイヤー2が投了</button>

--- a/battle_simulator_v2/core/effects/context.js
+++ b/battle_simulator_v2/core/effects/context.js
@@ -185,6 +185,10 @@ export class EffectContext {
       kind: 'confirm',
       player: this.playerIdx,
       title,
+      // デフォルトラベル（発動する/発動しない）= 任意効果の「発動するか」ゲート。
+      // 設定「任意効果の発動確認」がOFFのとき、エンジンが確認を出さず自動で発動(true)する対象。
+      // 中途の選択（独自ラベルの confirm。例「振る/振らない」）は対象外で常に確認する。
+      activation: yesLabel === '発動する' && noLabel === '発動しない',
       buildOptions: () => [
         { id: 'yes', label: yesLabel, value: true },
         { id: 'no', label: noLabel, value: false },

--- a/battle_simulator_v2/core/engine.js
+++ b/battle_simulator_v2/core/engine.js
@@ -74,6 +74,8 @@ export class Engine {
     this.onChange = opts.onChange || (() => {});
     // ステップ境界に「間」を入れる（UIが自動で進めることでドロー等の瞬間を見せる）
     this.stepPauses = opts.stepPauses !== false;
+    // 任意効果の発動確認（true=確認を出す/false=自動発動）。設定で切替。既定は確認する。
+    this.confirmOptionalEffects = opts.confirmOptionalEffects !== false;
     // カード効果システム（registry は事前に preload しておくこと）
     this.registry = opts.registry || new EffectRegistry();
     this.effects = new EffectSystem(this, this.registry);
@@ -304,6 +306,12 @@ export class Engine {
       return;
     }
     const request = r.value; // EffectContext.chooseXxx() が返す選択要求
+    // 任意効果の発動確認（設定OFF時）: 「発動するか」ゲートは確認を出さず自動で発動(true)する。
+    // 公式ルール上 自動能力は強制（任意コスト付きを除く）なので、ゲート対象は任意効果のみ。
+    if (request.kind === 'confirm' && request.activation && this.confirmOptionalEffects === false) {
+      this._stepEffect(gen, true, after);
+      return;
+    }
     const options = request.buildOptions();
     // デッキサーチで確認枠がある場合は、対象が無くても（skipのみ）デッキを見せるためモーダルを表示する
     const showDeckView = request.deckSearch && (request.displayCards || []).length > 0;

--- a/battle_simulator_v2/tests/test.js
+++ b/battle_simulator_v2/tests/test.js
@@ -953,6 +953,32 @@ export async function runTests() {
     assert(done, '完了しない');
   });
 
+  await testAsync('設定: 任意効果の発動確認ON/OFF（OFFは発動ゲートを自動発動、独自ラベルは常に確認）', async () => {
+    const e = await setupMainStep(deckMap, 134);
+
+    // (1) ON（既定）: 「発動する/発動しない」ゲートは確認モーダルを出す
+    e.confirmOptionalEffects = true;
+    let r1 = null; let done1 = false;
+    e._runEffect({ * run(ctx) { r1 = yield ctx.confirm('発動しますか？'); } }, { playerIdx: 0 }, () => { done1 = true; });
+    assert(!done1 && e.state.pending && e.state.pending.request.kind === 'confirm', 'ON: 確認モーダルが出ていない');
+    e.apply(e.state.pending.options.find((o) => o.id === 'yes').id);
+    assert(done1 && r1 === true, 'ON: 「発動する」で完了しない');
+
+    // (2) OFF: 発動ゲートは確認を出さず自動で true（発動）
+    e.confirmOptionalEffects = false;
+    let r2 = null; let done2 = false;
+    e._runEffect({ * run(ctx) { r2 = yield ctx.confirm('発動しますか？'); } }, { playerIdx: 0 }, () => { done2 = true; });
+    assert(done2 && r2 === true, 'OFF: 自動発動(true)で完了していない');
+    assert(!e.state.pending, 'OFF: 余計な pending が残っている');
+
+    // (3) OFF でも独自ラベルの confirm（中途選択）は確認を出す
+    let done3 = false;
+    e._runEffect({ * run(ctx) { yield ctx.confirm('振りますか？', '振る', '振らない'); } }, { playerIdx: 0 }, () => { done3 = true; });
+    assert(!done3 && e.state.pending && e.state.pending.request.kind === 'confirm', 'OFF: 独自ラベルconfirmまで自動化されている');
+    e.apply(e.state.pending.options[0].id);
+    assert(done3, '(3)完了しない');
+  });
+
   await testAsync('コンパイラ: 全カードでクラッシュせず、一定数を自動実装できる', async () => {
     let compiled = 0;
     let slots = 0;

--- a/battle_simulator_v2/ui/app.js
+++ b/battle_simulator_v2/ui/app.js
@@ -97,6 +97,7 @@ async function startGame() {
       names: ['プレイヤー1', 'プレイヤー2'],
       onChange: render,
       registry,
+      confirmOptionalEffects: getSettings().confirmOptionalEffects !== false, // 任意効果の発動確認（既定ON）
     });
     document.getElementById('setup-screen').style.display = 'none';
     document.getElementById('game-screen').classList.add('active');
@@ -1041,6 +1042,16 @@ function setupSettingsPanel() {
     refreshSettingsUI();
   });
 
+  // 任意効果の発動確認（確認する / 自動で発動）
+  document.getElementById('confirm-optional-buttons').addEventListener('click', (e) => {
+    const v = e.target.dataset?.confirmOptional;
+    if (!v) return;
+    const on = v === 'on';
+    saveSettings({ confirmOptionalEffects: on });
+    if (engine) engine.confirmOptionalEffects = on; // 実行中のゲームにも即反映
+    refreshSettingsUI();
+  });
+
   // AI適用（CPUが操作するプレイヤーの切り替え）
   document.getElementById('ai-buttons').addEventListener('click', (e) => {
     const idx = e.target.dataset?.ai;
@@ -1097,6 +1108,10 @@ function refreshSettingsUI() {
   }
   for (const btn of document.querySelectorAll('#ai-buttons button')) {
     btn.classList.toggle('active', aiEnabled(Number(btn.dataset.ai)));
+  }
+  const confirmOptOn = getSettings().confirmOptionalEffects !== false;
+  for (const btn of document.querySelectorAll('#confirm-optional-buttons button')) {
+    btn.classList.toggle('active', (btn.dataset.confirmOptional === 'on') === confirmOptOn);
   }
   document.getElementById('seed-display').textContent = `シード値: ${currentSeed ?? '-'}`;
 }


### PR DESCRIPTION
…nfirms; default ON (no behavior change), OFF auto-activates; rule-correct (mandatory auto-abilities unaffected) and avoids double-prompt; 57/57 tests pass