### PR TITLE
Implement エクストラ effects: parse into unlimitedInDeck/extraLifeLossOnDo…

### DIFF
--- a/battle_simulator_v2/cards/hBP06-083.js
+++ b/battle_simulator_v2/cards/hBP06-083.js
@@ -15,13 +15,8 @@
 export default {
   number: 'hBP06-083',
 
-  // 合体ユニット: このカードは〈角巻わため〉か〈大空スバル〉の上に重ねてBloomできる（別名Bloom）。
-  // レベル遷移・HP・ターン制限は通常のBloomと同じ（engine._canBloomIgnoreName で判定）。
-  bloomOnto(baseHolomem, card, engine) {
-    const baseName = baseHolomem.stack[0]?.name;
-    if (baseName !== '角巻わため' && baseName !== '大空スバル') return false;
-    return engine._canBloomIgnoreName(baseHolomem, card);
-  },
+  // 合体ユニット: エクストラ「このホロメンは〈角巻わため〉〈大空スバル〉としても扱う」を card_data から取得済み
+  //   → card.nameAliases として正規化され、engine._bloomNameMatches が別名Bloomを許可する（ハードコード不要）。
 
   collabEffect: {
     name: 'おしまいのあじまり',

--- a/battle_simulator_v2/core/cards.js
+++ b/battle_simulator_v2/core/cards.js
@@ -117,12 +117,22 @@ export function normalizeCard(raw) {
     } else if (skill.type === 'サポート効果') {
       card.supportText = fwColon(skill.name || skill.description || '');
     } else if (skill.type === 'エクストラ') {
-      // エクストラ「このホロメンはデッキに何枚でも入れられる」等。
-      // keywords にも積んで既存のサーチ判定（kw.text を見る）で拾えるようにする。
+      // エクストラ（永続のカード特性）。keywords にも積んで既存のサーチ判定（kw.text を見る）で拾えるようにする。
       const text = fwColon(skill.text || skill.name || '');
       card.keywords.push({ subtype: 'エクストラ', name: '', text });
-      // デッキ構築の同名上限を無視できる印（デッキビルダー等が参照可能）
+      // ①「このホロメンはデッキに何枚でも入れられる」: デッキ構築の同名上限を無視
       if (text.includes('デッキに何枚でも入れられる')) card.unlimitedInDeck = true;
+      // ②「ダウンした時、自分のライフ-N」: ダウン時に減るライフ枚数（Buzz=2 の明示。非Buzzでも-2の特殊カードあり）
+      const lm = /ダウンした時.*ライフ-(\d+)/.exec(text);
+      if (lm) card.extraLifeLossOnDown = Number(lm[1]);
+      // ③「このホロメンはBloomできない」: Bloム不可（Spotは元々不可だが念のため明示フラグ）
+      if (text.includes('Bloomできない')) card.cannotBloom = true;
+      // ④「このホロメンは〈X〉〈Y〉としても扱う」: 別名（合体ユニット。Bloム・〈名称〉参照で別名も一致）
+      const am = /このホロメンは(.+?)としても扱う/.exec(text);
+      if (am) {
+        const names = am[1].match(/〈([^〉]+)〉/g);
+        if (names) card.nameAliases = names.map((s) => s.replace(/[〈〉]/g, ''));
+      }
     } else if (skill.type === '推しステージスキル') {
       // 推しホロメンの常時能力（永続）。テキストを保持し、効果はカード定義の oshiStageSkill フックで実装する。
       card.oshiStageText = fwColon(skill.text || skill.name || '');

--- a/battle_simulator_v2/core/effects/context.js
+++ b/battle_simulator_v2/core/effects/context.js
@@ -64,9 +64,9 @@ export class EffectContext {
     return out;
   }
 
-  /** 名前一致（〈名称〉参照。追加カード名は未対応） */
+  /** 名前一致（〈名称〉参照）。エクストラ「〈X〉〈Y〉としても扱う」(nameAliases) の別名にも一致する */
   nameIs(card, name) {
-    return card.name === name;
+    return card.name === name || (card.nameAliases || []).includes(name);
   }
 
   /** タグ保持判定（#ID など。タグ表記は "ID" のように # 無しで格納されている） */

--- a/battle_simulator_v2/core/engine.js
+++ b/battle_simulator_v2/core/engine.js
@@ -1650,8 +1650,10 @@ export class Engine {
       if (h.noLifeOnDown) {
         this.log(`${p.name} のライフは減らない（効果による）`);
       } else {
-        // 「減るライフ-N」（onDown効果で h.lifeReductionOnDown を立てる）を反映
-        const lifeDmg = Math.max(0, (card.buzz ? 2 : 1) - (h.lifeReductionOnDown || 0));
+        // ダウン時に減るライフ枚数: エクストラ「ダウンした時、自分のライフ-N」を優先（非Buzzでも-2の特殊カード対応）、
+        // 無ければ Buzz=2 / 通常=1。さらに「減るライフ-N」(h.lifeReductionOnDown) を差し引く。
+        const baseLifeLoss = card.extraLifeLossOnDown ?? (card.buzz ? 2 : 1);
+        const lifeDmg = Math.max(0, baseLifeLoss - (h.lifeReductionOnDown || 0));
         p.lifeDamage += lifeDmg;
         this.log(`${p.name} はライフダメージ${lifeDmg}を受けた`);
       }
@@ -1961,19 +1963,29 @@ export class Engine {
 
   /** Bloom可否 (8.3.2-8.3.3) */
   _canBloom(h, card) {
-    if (topCard(h).name !== card.name) return false; // 同名であること
+    if (!this._bloomNameMatches(topCard(h), card)) return false; // 同名（または別名「としても扱う」）であること
     return this._canBloomIgnoreName(h, card);
   }
 
   /**
-   * 同名チェックを除いた Bloom 可否（faceDown/Spot/ターン制限/HP/レベル遷移）。
-   * 「別名のカードにBloomできる」特殊カード（ラムダック等の合体ユニット）の bloomOnto 判定に使う。
+   * Bloom の「同名」判定。エクストラ「このホロメンは〈X〉〈Y〉としても扱う」(card.nameAliases) を考慮し、
+   * 互いの名前/別名のいずれかが一致すれば同名扱い（合体ユニット: ラムダック/miComet/SorAZ/FUWAMOCO 等）。
+   */
+  _bloomNameMatches(baseTop, card) {
+    const baseNames = [baseTop.name, ...(baseTop.nameAliases || [])];
+    const cardNames = [card.name, ...(card.nameAliases || [])];
+    return baseNames.some((n) => cardNames.includes(n));
+  }
+
+  /**
+   * 同名チェックを除いた Bloom 可否（faceDown/Spot/Bloom不可/ターン制限/HP/レベル遷移）。
    */
   _canBloomIgnoreName(h, card) {
     const s = this.state;
     const top = topCard(h);
     if (h.faceDown) return false;
     if (top.bloomLevel === 'Spot') return false;
+    if (top.cannotBloom) return false; // エクストラ「このホロメンはBloomできない」
     if (h.placedTurn === s.turn) return false;       // このターンに出たホロメンは不可
     if (h.bloomedTurn === s.turn) return false;      // このターンにBloom済みは不可
     if (card.hp <= h.damage) return false;           // 新HPがダメージを超えていること（「より大きい」）

--- a/battle_simulator_v2/tests/test.js
+++ b/battle_simulator_v2/tests/test.js
@@ -1037,6 +1037,29 @@ export async function runTests() {
     assert(d2 && p0.holoPower.length === hp0 + 1 && p0.deck.length === dk0 - 1, 'わため: デッキ上1枚がホロパワーに行っていない');
   });
 
+  await testAsync('エクストラ: 名前読み替え（ラムダックが〈角巻わため〉にBloomできる / nameIs別名一致）', async () => {
+    const e = await setupMainStep(deckMap, 150);
+    const ramuduck = lib.getByNumber('hBP06-083'); // ラムダック1st、nameAliases=[角巻わため,大空スバル]
+    assert((ramuduck.nameAliases || []).includes('角巻わため'), 'nameAliases が正規化されていない');
+    const base = e._createHolomem(lib.getByNumber('hBP07-008'), 0); // Debut〈角巻わため〉
+    base.placedTurn = 0;
+    assertEq(base.stack[0].name, '角巻わため', 'テスト用の素体が〈角巻わため〉でない');
+    assert(e._canBloom(base, ramuduck), 'ラムダックが〈角巻わため〉にBloomできない（別名Bloム）');
+    const ctx = new EffectContext(e, 0, {});
+    assert(ctx.nameIs(ramuduck, '角巻わため') && ctx.nameIs(ramuduck, '大空スバル'), 'nameIs が別名に一致しない');
+    assert(!ctx.nameIs(ramuduck, '無関係'), 'nameIs が無関係名に一致している');
+  });
+
+  await testAsync('エクストラ: ダウン時ライフ-2（非Buzz）の正規化 / Bloomできない（Spot）の正規化', async () => {
+    assertEq(lib.getByNumber('hBP07-019').extraLifeLossOnDown, 2, '非Buzzの「ライフ-2」が正規化されていない');
+    assert(lib.getByNumber('hBP01-096').cannotBloom === true, 'Spotの cannotBloom が立っていない');
+    // Buzz は従来どおり（extraLifeLossOnDown が無くても card.buzz=2 経路）/ 通常ホロメンは undefined
+    const e = await setupMainStep(deckMap, 151);
+    // Spot にはBloムできない（同名上位でも不可。_canBloomIgnoreName の Spot/cannotBloom 判定）
+    const spotH = e._createHolomem(lib.getByNumber('hBP01-096'), 0); spotH.placedTurn = 0;
+    assert(!e._canBloomIgnoreName(spotH, { bloomLevel: '1st', hp: 200 }), 'Spot/cannotBloom にBloомできてしまう');
+  });
+
   await testAsync('コンパイラ: 全カードでクラッシュせず、一定数を自動実装できる', async () => {
     let compiled = 0;
     let slots = 0;


### PR DESCRIPTION
…wn/cannotBloom/nameAliases; fix non-Buzz "ライフ-2" on down, add cannotBloom guard, and support alias-name Bloom (generalizing ラムダック; also FUWAMOCO/miComet/SorAZ) + alias-aware nameIs; 60/60 tests pass