### PR TITLE
スマホ盤面の拡大（ゾーン再配置＋テーブル縮小で約6割拡大）と、先攻後攻決定（ランダム/手動）＋手札引き直しの対戦前専用モーダル化（PC共通…

### DIFF
--- a/battle_simulator_v2.html
+++ b/battle_simulator_v2.html
@@ -126,6 +126,15 @@
       <!-- 盤面確認中に選択へ戻るボタン -->
       <button id="choice-restore">▲ カード選択に戻る</button>
 
+      <!-- 対戦開始前のモーダル（先攻後攻の決定・最初の手札の引き直し） -->
+      <div id="pregame-modal">
+        <div id="pregame-content">
+          <div id="pregame-title"></div>
+          <div id="pregame-body"></div>
+          <div id="pregame-actions"></div>
+        </div>
+      </div>
+
       <!-- ターン切り替え通知 -->
       <div id="turn-toast"></div>
 

--- a/battle_simulator_v2/core/engine.js
+++ b/battle_simulator_v2/core/engine.js
@@ -87,7 +87,7 @@ export class Engine {
         createPlayerState(names[0], opts.decks[0]),
         createPlayerState(names[1], opts.decks[1]),
       ],
-      firstPlayer: opts.firstPlayer ?? (this.rng() < 0.5 ? 0 : 1),
+      firstPlayer: opts.firstPlayer ?? null, // null = start() で決定（ランダム/手動選択の決定ポイントを出す）
       turnPlayer: 0,
       turn: 0,                 // 全体のターン番号（1始まり）
       step: null,
@@ -122,15 +122,26 @@ export class Engine {
   /** ゲーム開始（最初の決定ポイントまで進む） */
   start() {
     const s = this.state;
-    const first = s.firstPlayer;
-    this.log(`先攻: ${s.players[first].name}`);
     for (const p of s.players) {
       shuffle(p.deck, this.rng);
       shuffle(p.cheerDeck, this.rng);
       this._drawCards(p, INITIAL_HAND);
     }
-    // セットアップの決定キュー: 引き直き(先攻→後攻) → マリガン(自動) → 配置(先攻→後攻)
-    this._setupQueue = [
+    if (s.firstPlayer == null) {
+      // 先攻・後攻が未指定なら、最初の決定ポイントで決める（ランダム/手動）。
+      // 決定後に _buildSetupQueue で残りのセットアップ手順を積む。
+      this._setupQueue = [{ kind: 'chooseFirstPlayer' }];
+    } else {
+      this.log(`先攻: ${s.players[s.firstPlayer].name}`);
+      this._setupQueue = this._buildSetupQueue(s.firstPlayer);
+    }
+    this._advanceSetup();
+    this.onChange();
+  }
+
+  /** 先攻決定後のセットアップ手順: 引き直し(先攻→後攻) → マリガン(自動) → 配置(先攻→後攻) */
+  _buildSetupQueue(first) {
+    return [
       { kind: 'redraw', player: first },
       { kind: 'redraw', player: 1 - first },
       { kind: 'mulligan' },
@@ -142,8 +153,6 @@ export class Engine {
       { kind: 'placementBack', player: 1 - first },
       { kind: 'finishSetup' },
     ];
-    this._advanceSetup();
-    this.onChange();
   }
 
   /** 選択肢を適用して次の決定ポイントまで進む */
@@ -427,6 +436,17 @@ export class Engine {
       const item = this._setupQueue.shift();
       if (!item) return;
       switch (item.kind) {
+        case 'chooseFirstPlayer': {
+          s.pending = {
+            type: 'chooseFirstPlayer', player: null,
+            options: [
+              { id: 'random', label: '🎲 ランダムで決める' },
+              { id: 'first_0', label: `${s.players[0].name} が先攻`, value: 0 },
+              { id: 'first_1', label: `${s.players[1].name} が先攻`, value: 1 },
+            ],
+          };
+          break;
+        }
         case 'redraw': {
           const p = s.players[item.player];
           s.pending = {
@@ -1186,6 +1206,14 @@ export class Engine {
   _execute(pending, action) {
     const s = this.state;
     switch (pending.type) {
+      case 'chooseFirstPlayer': {
+        const first = action.id === 'random' ? (this.rng() < 0.5 ? 0 : 1) : action.value;
+        s.firstPlayer = first;
+        this.log(`先攻: ${s.players[first].name}${action.id === 'random' ? '（ランダム）' : '（指定）'}`);
+        this._setupQueue = this._buildSetupQueue(first);
+        this._advanceSetup();
+        break;
+      }
       case 'redraw': {
         const p = s.players[pending.player];
         if (action.id === 'yes') {

--- a/battle_simulator_v2/css/board.css
+++ b/battle_simulator_v2/css/board.css
@@ -1129,6 +1129,61 @@ body.dragging, body.dragging * { cursor: grabbing !important; }
   cursor: pointer;
 }
 
+/* ===== 対戦開始前モーダル（先攻後攻の決定 / 最初の手札の引き直し）PC・スマホ共通 ===== */
+#pregame-modal {
+  position: absolute;
+  inset: 0;
+  background: rgba(5, 6, 18, 0.82);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 105;
+  padding: 16px;
+}
+#pregame-modal.active { display: flex; }
+#pregame-content {
+  background: #141630;
+  border: 1px solid var(--accent);
+  border-radius: 14px;
+  width: min(640px, 94vw);
+  max-height: 90vh;
+  overflow-y: auto;
+  padding: 22px 24px;
+  box-shadow: 0 0 60px rgba(110, 195, 255, 0.3);
+  text-align: center;
+}
+#pregame-title { font-size: 1.3em; font-weight: bold; color: #fff; margin-bottom: 12px; }
+.pregame-note { color: #aab; font-size: 0.9em; line-height: 1.6; margin-bottom: 16px; }
+.pregame-hand {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  justify-content: center;
+  margin-bottom: 18px;
+}
+.pregame-hand img {
+  width: 84px;
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+}
+#pregame-actions { display: flex; flex-wrap: wrap; gap: 10px; justify-content: center; }
+.pregame-btn {
+  padding: 12px 22px;
+  font-size: 1em;
+  background: #222654;
+  border: 1px solid #3c4185;
+  color: #dde;
+  border-radius: 10px;
+  cursor: pointer;
+}
+.pregame-btn:hover { background: #2e3470; border-color: var(--accent); }
+.pregame-btn.primary {
+  background: linear-gradient(135deg, #4a7cff, #9a4aff);
+  border-color: var(--accent);
+  color: #fff;
+  font-weight: bold;
+}
+
 /* スマホ用要素は既定（PC）では非表示 */
 .mobile-only { display: none; }
 
@@ -1147,7 +1202,22 @@ body.dragging, body.dragging * { cursor: grabbing !important; }
   #setup-screen { min-width: 0; width: min(92vw, 420px); padding: 22px 20px; }
 
   /* 盤面シーンを全幅に（右パネル分の余白を無くす） */
-  .scene { right: 0; }
+  .scene { right: 0; perspective-origin: 50% 38%; }
+
+  /* 盤面の拡大: 横長レイアウトを縦画面向けに詰めて、テーブル自体を縮める。
+     ゾーンを左右の死スペースを削って再配置し、テーブル幅を 1060→760 に縮小する。
+     これにより updateBoardScale の拡大率が上がり、盤面が大きく見える。 */
+  .table { width: 664px; height: 720px; }
+  .zone.life      { left: 4px;   top: 40px;  min-width: 92px;  min-height: 150px; }
+  .zone.cheerdeck { left: 4px;   top: 214px; }
+  .zone.collab    { left: 104px; top: 18px; }
+  .zone.center    { left: 212px; top: 18px; }
+  .zone.oshi      { left: 320px; top: 18px; }
+  .zone.revealed  { left: 428px; top: 150px; }
+  .zone.holopower { left: 432px; top: 6px; }
+  .zone.deck      { left: 556px; top: 18px; }
+  .zone.backs     { left: 104px; top: 200px; min-width: 452px; min-height: 120px; }
+  .zone.archive   { left: 556px; top: 196px; }
 
   /* 右の固定パネル → 下からのボトムシート */
   #side-panel {

--- a/battle_simulator_v2/tests/test.js
+++ b/battle_simulator_v2/tests/test.js
@@ -378,6 +378,38 @@ export async function runTests() {
     assertEq(e.state.turnPlayer, 0);
   });
 
+  test('先攻決定: firstPlayer未指定なら最初の決定ポイントが chooseFirstPlayer（手動指定）', () => {
+    const d0 = lib.buildGameDeck(deckMap);
+    const d1 = lib.buildGameDeck(deckMap);
+    const e = new Engine({ decks: [d0, d1], seed: 42 }); // firstPlayer 未指定
+    e.start();
+    assertEq(e.state.pending.type, 'chooseFirstPlayer', '先攻決定が最初の決定ポイントになっていない');
+    assertEq(e.state.firstPlayer, null, '先攻決定前に firstPlayer が確定している');
+    e.apply('first_1'); // プレイヤー2(index1)を先攻に指定
+    assertEq(e.state.firstPlayer, 1, '手動指定した先攻(1)が反映されていない');
+    assertEq(e.state.pending.type, 'redraw', '先攻決定後に引き直しへ進んでいない');
+    assertEq(e.state.pending.player, 1, '引き直しの順が先攻(1)から始まっていない');
+  });
+
+  test('先攻決定: ランダム選択は有効な先攻を確定する', () => {
+    const d0 = lib.buildGameDeck(deckMap);
+    const d1 = lib.buildGameDeck(deckMap);
+    const e = new Engine({ decks: [d0, d1], seed: 42 });
+    e.start();
+    e.apply('random');
+    assert(e.state.firstPlayer === 0 || e.state.firstPlayer === 1, 'ランダムで先攻が確定していない');
+    assertEq(e.state.pending.type, 'redraw', 'ランダム決定後に引き直しへ進んでいない');
+  });
+
+  test('先攻決定: firstPlayer指定時は chooseFirstPlayer を出さず即引き直し（後方互換）', () => {
+    const d0 = lib.buildGameDeck(deckMap);
+    const d1 = lib.buildGameDeck(deckMap);
+    const e = new Engine({ decks: [d0, d1], seed: 42, firstPlayer: 0 });
+    e.start();
+    assertEq(e.state.pending.type, 'redraw', 'firstPlayer指定時に余計な先攻決定が出ている');
+    assertEq(e.state.firstPlayer, 0, 'firstPlayer指定が反映されていない');
+  });
+
   await testAsync('ランダムプレイアウト×5シード（保存則・クラッシュ無し・決着）', async () => {
     for (const seed of [1, 2, 3, 4, 5]) {
       const { engine, applies } = await randomPlayout(lib, deckMap, seed);
@@ -1819,7 +1851,8 @@ export async function runTests() {
       while (e.state.phase !== 'ended' && applies < 4000) {
         const pending = e.state.pending;
         assert(pending, `seed=${seed}: pending が無いのに終わっていない`);
-        const id = ais[pending.player].choose(e);
+        // 先攻決定(player=null)はランダム(先頭の選択肢)で。それ以外は各AIが選ぶ
+        const id = pending.player == null ? pending.options[0].id : ais[pending.player].choose(e);
         e.apply(id);
         applies++;
       }

--- a/battle_simulator_v2/ui/app.js
+++ b/battle_simulator_v2/ui/app.js
@@ -722,7 +722,7 @@ function render() {
   const humans = [0, 1].filter((i) => !aiEnabled(i));
   const handPlayer = humans.length === 1
     ? humans[0]
-    : (s.pending ? s.pending.player : s.turnPlayer);
+    : (s.pending && s.pending.player != null ? s.pending.player : s.turnPlayer);
   renderHand(document.getElementById('hand'), s.players[handPlayer].hand, handPlayer, hooks);
   renderOppHand(document.getElementById('opp-hand'), s.players[1 - handPlayer].hand.length);
 
@@ -734,6 +734,7 @@ function render() {
   wireDnD();
   renderStatus(s, handPlayer);
   renderMobileControls(s);
+  renderPregameModal(s);
   renderActions(s);
   renderEffectChoiceModal(s);
   renderLog(s);
@@ -912,7 +913,7 @@ function renderEffectChoiceModal(s) {
 function renderStatus(s, handPlayer) {
   const status = document.getElementById('status');
   const stepName = s.step ? STEP_NAMES[s.step] : 'セットアップ';
-  const pendingName = s.pending ? s.players[s.pending.player].name : '';
+  const pendingName = s.pending && s.pending.player != null ? s.players[s.pending.player].name : '';
   status.innerHTML = `
     <div class="turn-banner">ターン${s.turn || '-'} ・ ${stepName}</div>
     <div>ターンプレイヤー: ${s.players[s.turnPlayer]?.name || '-'}</div>
@@ -965,10 +966,67 @@ function renderMobileControls(s) {
   if (toggle) {
     const hasActions = !!(s.pending
       && s.pending.type !== 'stepPause' && s.pending.type !== 'effectChoice'
+      && s.pending.type !== 'chooseFirstPlayer' && s.pending.type !== 'redraw'
       && (s.pending.player == null || !aiEnabled(s.pending.player))
       && (s.pending.options || []).length > 0);
     toggle.classList.toggle('has-actions', hasActions);
   }
+}
+
+/**
+ * 対戦開始前の専用モーダル（先攻後攻の決定 / 最初の手札の引き直し）。PC・スマホ共通。
+ * これらは盤面操作ではなく「対戦が始まる前の初期設定」なので、右パネルではなく
+ * 中央モーダルで提示する。AIプレイヤーの手番は自動処理に任せ、モーダルは出さない。
+ */
+function renderPregameModal(s) {
+  const modal = document.getElementById('pregame-modal');
+  const pending = s.pending;
+  const isPregame = !!pending && (pending.type === 'chooseFirstPlayer' || pending.type === 'redraw');
+  // 引き直しがAIの手番なら自動処理（handleAI）に任せ、モーダルは出さない
+  if (isPregame && pending.type === 'redraw' && aiEnabled(pending.player)) { modal.classList.remove('active'); return; }
+  if (!isPregame) { modal.classList.remove('active'); return; }
+
+  const title = document.getElementById('pregame-title');
+  const body = document.getElementById('pregame-body');
+  const actions = document.getElementById('pregame-actions');
+  body.innerHTML = '';
+  actions.innerHTML = '';
+
+  if (pending.type === 'chooseFirstPlayer') {
+    // 両者AI（人間の操作者がいない）の場合は自動でランダム決定
+    if (aiEnabled(0) && aiEnabled(1)) { engine.apply('random'); return; }
+    title.textContent = '⚔️ 先攻・後攻を決める';
+    body.innerHTML = '<div class="pregame-note">先攻プレイヤーを決定します。ランダムで決めるか、手動で指定できます。</div>';
+    for (const opt of pending.options) {
+      const btn = document.createElement('button');
+      btn.className = 'pregame-btn' + (opt.id === 'random' ? ' primary' : '');
+      btn.textContent = opt.label;
+      btn.addEventListener('click', () => engine.apply(opt.id));
+      actions.appendChild(btn);
+    }
+  } else { // redraw
+    const p = s.players[pending.player];
+    title.textContent = `🃏 ${p.name}：最初の手札`;
+    body.innerHTML = '<div class="pregame-note">この手札で対戦を始めますか？「引き直す」を選ぶと、手札を全てデッキに戻してシャッフルし、引き直します（このターンに1回だけ）。</div>';
+    const hand = document.createElement('div');
+    hand.className = 'pregame-hand';
+    for (const c of p.hand) {
+      const img = document.createElement('img');
+      img.src = c.imageUrl || '';
+      img.alt = c.name;
+      img.loading = 'lazy';
+      hand.appendChild(img);
+    }
+    body.appendChild(hand);
+    for (const opt of pending.options) {
+      const btn = document.createElement('button');
+      btn.className = 'pregame-btn' + (opt.id === 'no' ? ' primary' : '');
+      btn.textContent = opt.label;
+      btn.addEventListener('click', () => engine.apply(opt.id));
+      actions.appendChild(btn);
+    }
+  }
+  modal.classList.add('active');
 }
 
 function pendingHint(pending) {
@@ -992,6 +1050,8 @@ function renderActions(s) {
   const box = document.getElementById('actions');
   box.innerHTML = '';
   if (!s.pending) return;
+  // 先攻後攻の決定・引き直しは専用モーダル(renderPregameModal)で扱うため右パネルには出さない
+  if (s.pending.type === 'chooseFirstPlayer' || s.pending.type === 'redraw') return;
 
   const hint = document.createElement('div');
   hint.className = 'actions-title';
@@ -1241,17 +1301,21 @@ const MOBILE_MQ = window.matchMedia('(max-width: 768px)');
 function isMobileLayout() { return MOBILE_MQ.matches; }
 
 function updateBoardScale() {
-  let sceneW, sceneH;
+  let sceneW, sceneH, divW, divH;
   if (isMobileLayout()) {
     // スマホ: 盤面は全幅。上の概要バー(約44px)と下の手札(約120px)ぶんを縦に確保する。
-    sceneW = window.innerWidth - 12;
-    sceneH = window.innerHeight - 44 - 120;
+    // テーブルはモバイル用に 664×720 へ詰めてあるので、その投影footprintで割る。
+    sceneW = window.innerWidth - 8;
+    sceneH = window.innerHeight - 44 - 116;
+    divW = 690;            // 664 + 余白
+    divH = 660;            // 720 * 投影0.83 + 余白
   } else {
     sceneW = window.innerWidth - 320 - 16; // サイドパネルと余白を除く
     sceneH = window.innerHeight - 16;
+    divW = 1100;
+    divH = 760;            // rotateX(34deg) 投影後の高さは約 0.83 倍 + はみ出し分
   }
-  // rotateX(34deg) 投影後の高さは約 0.83 倍 + 手前へのはみ出し分を見込む
-  const scale = Math.min(1, sceneW / 1100, sceneH / 760);
+  const scale = Math.min(1, sceneW / divW, sceneH / divH);
   document.documentElement.style.setProperty('--board-scale', String(scale));
 }
 


### PR DESCRIPTION
…）。先攻決定の決定ポイントをエンジンに追加し回帰テスト3件追加（90/90）