### PR TITLE
全色/フワモコ系8件修正: 「相手の推しと異なる色」効果を全色扱い対応(hBP08-068/071/072/074, 原因は消費側のリテラ…

### DIFF
--- a/battle_simulator_v2/cards/hBP03-038.js
+++ b/battle_simulator_v2/cards/hBP03-038.js
@@ -13,6 +13,10 @@ export default {
   bloomEffect: {
     name: '遊びの時間だー！',
     *run(ctx) {
+      // 「DebutからBloomした時」: Bloom元（重なりの下＝stack[1]）がDebutの時のみ発動。
+      // 1st→1st の同レベルBloom（公式で可）では発動しない。
+      const prev = ctx.sourceHolomem?.stack?.[1];
+      if (prev && prev.bloomLevel !== 'Debut') return;
       const candidates = ctx.deckCards(
         (c) => c.name === 'フワワ・アビスガード' && c.bloomLevel === '1st'
       );

--- a/battle_simulator_v2/cards/hBP07-051.js
+++ b/battle_simulator_v2/cards/hBP07-051.js
@@ -14,21 +14,23 @@ export default {
       const isDest = (e) => e.holomem !== self && ctx.hasTag(e.top, 'Promise');
       // 付け替え可能なエール＝「そのエールの所有者(from)とは別の」付け替え先が存在するエールだけを候補にする。
       // （付け替え＝別のホロメンへ移すこと。所有者自身へは送れない＝no-op を作らない）
-      const entries = [];
-      for (const e of ctx.holomems('self')) {
-        const hasOtherDest = ctx.holomems('self', (d) => isDest(d) && d.holomem !== e.holomem).length > 0;
-        if (!hasOtherDest) continue;
-        for (const cheer of e.holomem.cheers) entries.push({ cheer, from: e.holomem });
-      }
-      if (entries.length === 0) return; // 付け替えられるエールが無ければ何もしない
+      // 付け替え「元」になれるホロメン＝エールを持ち、かつ「自分以外の付け替え先」が存在するもの。
+      const canBeFrom = (e) => e.holomem.cheers.length > 0
+        && ctx.holomems('self', (d) => isDest(d) && d.holomem !== e.holomem).length > 0;
+      if (ctx.holomems('self', canBeFrom).length === 0) return; // 付け替えられるエールが無ければ何もしない
       const ok = yield ctx.confirm('エール1枚を #Promise ホロメンに付け替えますか？');
       if (!ok) return;
-      const picked = yield ctx.chooseCard({
-        cards: entries.map((e) => e.cheer),
-        title: '付け替えるエールを選択',
+      // まず「元」のホロメンを盤面で選ぶ（盤上カードが光り、どのホロメンのエールか一目で分かる）
+      const fromEntry = yield ctx.chooseHolomem({
+        side: 'self', filter: canBeFrom, optional: true,
+        title: '付け替えるエールの「元」のホロメンを選択',
       });
+      if (!fromEntry) return;
+      const from = fromEntry.holomem;
+      const cheers = [...from.cheers];
+      const picked = cheers.length === 1 ? cheers[0]
+        : yield ctx.chooseCard({ cards: cheers, title: `〈${from.stack[0].name}〉の付け替えるエールを選択`, optional: true });
       if (!picked) return;
-      const from = entries.find((e) => e.cheer === picked).from;
       const target = yield ctx.chooseHolomem({
         side: 'self',
         filter: (e) => isDest(e) && e.holomem !== from, // このホロメン以外の#Promise、かつ元の所有者とは別

--- a/battle_simulator_v2/cards/hBP08-034.js
+++ b/battle_simulator_v2/cards/hBP08-034.js
@@ -30,23 +30,25 @@ export default {
         return;
       }
 
-      // Debutホロメンの〈フワワ・アビスガード〉と〈モココ・アビスガード〉を1枚ずつステージに出す
+      // Debutホロメンの〈フワワ・アビスガード〉と〈モココ・アビスガード〉を1枚ずつステージに出す。
+      // 各名称に複数候補（別カード）があり得るので、どれを出すかはプレイヤーが選ぶ（勝手に出さない）。
       const names = ['フワワ・アビスガード', 'モココ・アビスガード'];
       for (const name of names) {
-        const card = ctx.deckCards(
-          (c) => c.kind === 'holomen' && c.bloomLevel === 'Debut' && c.name === name,
-        )[0];
-        if (!card) {
+        if (ctx.engine._stageCount(ctx.player) >= 6) break; // ステージ上限
+        const cand = ctx.deckCards(
+          (c) => c.kind === 'holomen' && c.bloomLevel === 'Debut' && c.name === name);
+        if (cand.length === 0) {
           ctx.log(`デッキにDebutの〈${name}〉が見つからなかった`);
           continue;
         }
+        const card = yield ctx.chooseCard({
+          cards: cand,
+          title: `ステージに出すDebutの〈${name}〉を選択`,
+        });
+        if (!card) continue;
         ctx.removeFromDeck(card);
         ctx.flashReveal(card); // どのカードを出したか画面に見せる
-        if (!ctx.putToBack(card)) {
-          // ステージ上限などで出せなかった場合はデッキに戻す（領域に属さない瞬間を作らない）
-          ctx.deckToBottom([card]);
-          ctx.log(`ステージに空きがなく〈${name}〉を出せなかった`);
-        }
+        ctx.putToBack(card);
       }
 
       // そしてデッキをシャッフルする

--- a/battle_simulator_v2/cards/hBP08-039.js
+++ b/battle_simulator_v2/cards/hBP08-039.js
@@ -26,10 +26,10 @@ export default {
   bloomEffect: {
     name: '深淵からの信頼',
     *run(ctx) {
-      // 自分のステージ全体の青エール枚数
+      // 自分のステージ全体の青エール枚数（赤→青のエイリアス＝hBP08-003 推しステージスキル等を反映）
       let blue = 0;
       for (const e of ctx.holomems('self')) {
-        blue += (e.holomem.cheers || []).filter((c) => c.color === '青').length;
+        blue += ctx.cheerCountOfColor(e.holomem, '青');
       }
       if (blue < 6) {
         ctx.log('深淵からの信頼: 青エールが6枚未満のため発動しない');
@@ -53,16 +53,16 @@ export default {
 
   arts: {
     'もこもこバウンティハンター': {
-      // このホロメンの青エール1枚につき +20
+      // このホロメンの青エール1枚につき +20（赤→青エイリアス反映）
       dmgBonus(ctx) {
-        const blue = (ctx.sourceHolomem?.cheers || []).filter((c) => c.color === '青').length;
-        return blue * 20;
+        return (ctx.sourceHolomem ? ctx.cheerCountOfColor(ctx.sourceHolomem, '青') : 0) * 20;
       },
       *run(ctx) {
         const self = ctx.sourceHolomem;
         if (!self) return;
+        const isBlue = (c) => ctx.cheerEffectiveColors(self, c).has('青'); // 赤→青エイリアス反映
         // このホロメンの青エールが無ければ付け替え不可
-        if (!(self.cheers || []).some((c) => c.color === '青')) return;
+        if (!(self.cheers || []).some(isBlue)) return;
         // 付け替え先の〈フワワ・アビスガード〉1人（自分自身が〈フワワ〉でない前提だが名前で判定）
         const targets = ctx.holomems('self', (e) => ctx.nameIs(e.top, FUWAWA) && e.holomem !== self);
         if (targets.length === 0) return;
@@ -79,7 +79,7 @@ export default {
 
         // 好きな枚数（このホロメンの青エールの数まで・0枚で打ち切り可）を1枚ずつ付け替える
         while (true) {
-          const blueCheers = (self.cheers || []).filter((c) => c.color === '青');
+          const blueCheers = (self.cheers || []).filter(isBlue);
           if (blueCheers.length === 0) break;
           const picked = yield ctx.chooseCard({
             cards: blueCheers,

--- a/battle_simulator_v2/cards/hBP08-068.js
+++ b/battle_simulator_v2/cards/hBP08-068.js
@@ -48,7 +48,8 @@ export default {
         // 相手のセンターとコラボのうち、推しと「異なる色」を持つホロメンが対象（条件一致の全員）
         const targets = ctx.holomems(
           'opp',
-          (e) => (e.pos.zone === 'center' || e.pos.zone === 'collab') && e.top.color !== oshiColor,
+          (e) => (e.pos.zone === 'center' || e.pos.zone === 'collab')
+            && (ctx.isAllColors(e.holomem) || e.top.color !== oshiColor), // 全色扱いも「異なる色」
         );
         for (const t of targets) {
           yield* ctx.dealSpecialDamage(t, 20);

--- a/battle_simulator_v2/cards/hBP08-071.js
+++ b/battle_simulator_v2/cards/hBP08-071.js
@@ -22,7 +22,7 @@ export default {
     *run(ctx) {
       const oshiColor = ctx.opponent.oshi?.color || null;
       // 相手の推しホロメンと「異なる色を持つ」相手のホロメンのみ対象
-      const filter = (e) => e.top.color !== oshiColor;
+      const filter = (e) => ctx.isAllColors(e.holomem) || e.top.color !== oshiColor; // 全色扱いも「異なる色」
       const candidates = ctx.holomems('opp', filter);
       if (candidates.length === 0) {
         ctx.log('TOMORROW!?: 相手の推しホロメンと異なる色を持つホロメンがいない');

--- a/battle_simulator_v2/cards/hBP08-072.js
+++ b/battle_simulator_v2/cards/hBP08-072.js
@@ -58,7 +58,7 @@ export default {
       dmgBonus(ctx) {
         // 相手の推しホロメンと異なる色を持つ相手のステージのホロメン1人につき +10
         const oshiColor = ctx.opponent.oshi?.color;
-        const count = ctx.holomems('opp', (e) => e.top.color && e.top.color !== oshiColor).length;
+        const count = ctx.holomems('opp', (e) => ctx.isAllColors(e.holomem) || (e.top.color && e.top.color !== oshiColor)).length;
         return count * 10;
       },
     },

--- a/battle_simulator_v2/cards/hBP08-074.js
+++ b/battle_simulator_v2/cards/hBP08-074.js
@@ -35,7 +35,7 @@ export default {
       }
       const oshiColor = ctx.opponent.oshi?.color || null;
       // 相手の推しホロメンと異なる色を持つ、相手ステージのホロメンを数える
-      const diff = ctx.holomems('opp', (e) => e.top.color !== oshiColor);
+      const diff = ctx.holomems('opp', (e) => ctx.isAllColors(e.holomem) || e.top.color !== oshiColor); // 全色扱いも「異なる色」
       if (diff.length === 0) {
         ctx.log('目覚めよ、赤き眼の黒龍: 推しと異なる色のホロメンがいない');
         return;

--- a/battle_simulator_v2/cards/hBP08-104.js
+++ b/battle_simulator_v2/cards/hBP08-104.js
@@ -27,6 +27,11 @@ export default {
       if (!top) return;
       // ◆〈水宮枢〉に付いていたら能力追加
       if (top.name !== '水宮枢') return;
+      // 「Bloomレベルが上がった時」= レベルが実際に上昇した時のみ。
+      // 1st→1st / 2nd→2nd の同レベルBloom（公式で可）では引かない。
+      const RANK = { Debut: 0, '1st': 1, '2nd': 2 };
+      const prev = host.stack[1]; // Bloom前のカード（重なりの下）
+      if (!prev || (RANK[top.bloomLevel] ?? 0) <= (RANK[prev.bloomLevel] ?? 0)) return;
       ctx.draw(1);
     },
   },

--- a/battle_simulator_v2/core/effects/context.js
+++ b/battle_simulator_v2/core/effects/context.js
@@ -81,6 +81,31 @@ export class EffectContext {
     return card.name === name || (card.nameAliases || []).includes(name);
   }
 
+  /**
+   * エール cheer が holomem に付いている時の「実効的な色」集合（推しステージスキルの
+   * エール色エイリアスを反映）。例: FUWAMOCO(hBP08-003) では〈フワワ/モココ〉の赤エールは青も含む。
+   * 効果テキストの「○色エール」判定（枚数カウント・付け替え候補等）はこれを使うこと。
+   */
+  cheerEffectiveColors(holomem, cheer) {
+    const colors = new Set([cheer.color]);
+    const oshiStage = this.engine._oshiStage(this.playerIdx);
+    if (oshiStage?.cheerColorAlias) {
+      for (const c of oshiStage.cheerColorAlias(holomem, cheer, this.engine, this.playerIdx) || []) colors.add(c);
+    }
+    return colors;
+  }
+
+  /** holomem に付いた「実効色 color」のエール枚数（エイリアス反映） */
+  cheerCountOfColor(holomem, color) {
+    return (holomem.cheers || []).filter((c) => this.cheerEffectiveColors(holomem, c).has(color)).length;
+  }
+
+  /** ホロメンが「すべての色を持つ」として扱われているか（全色扱い。Takodachi/Ina推しスキル等）。
+   *  「○色と異なる色を持つ」等の色条件はこれを考慮すること（全色なら必ず該当）。 */
+  isAllColors(holomem) {
+    return this.engine._isTreatedAllColors(holomem);
+  }
+
   /** タグ保持判定（#ID など。タグ表記は "ID" のように # 無しで格納されている） */
   hasTag(card, tag) {
     const t = tag.replace(/^#/, '');

--- a/battle_simulator_v2/tests/test.js
+++ b/battle_simulator_v2/tests/test.js
@@ -579,6 +579,61 @@ export async function runTests() {
       'CPUの選択(choose)と最善ID(bestOptionId)が不一致＝CPUと表示の物差しがずれている');
   });
 
+  await testAsync('全色扱い: 「相手の推しと異なる色」効果が全色の相手を対象にできる(hBP08-071)', async () => {
+    const e = await setupMainStep(deckMap, 181);
+    await e.registry.preload(['hBP08-071'], lib);
+    const p0 = e.state.players[0]; const p1 = e.state.players[1];
+    p1.oshi = { number: 'x', name: '敵推し', color: '赤', kind: 'holomen', life: 5 };
+    const oppC = e._createHolomem(fakeHolomen({ name: '敵C', color: '赤' }), 1); // 推しと同色→通常は対象外
+    p1.center = oppC; p1.collab = null; p1.back = [];
+    const def = e.registry.get('hBP08-071');
+    // 全色付与前: 同色なので対象なし（候補ゼロでreturn）
+    let r = def.bloomEffect.run(e._effectContext(0, { sourceHolomem: p0.center })).next();
+    assert(r.done, '同色なのに対象になっている（前提崩れ）');
+    // 全色付与後: 「異なる色を持つ」と扱われ対象になる
+    e.state.modifiers.push({ kind: 'treatedAllColors', ownerIdx: 0, match: (h) => h === oppC });
+    r = def.bloomEffect.run(e._effectContext(0, { sourceHolomem: p0.center })).next();
+    assertEq(r.value?.kind, 'chooseHolomem', '全色の相手を特殊ダメージ対象にできていない');
+    const names = r.value.buildOptions().filter((o) => o.value).map((o) => o.value.top.name);
+    assert(names.includes('敵C'), '全色の相手センターが対象候補に含まれない');
+  });
+
+  await testAsync('hBP03-038 遊びの時間: DebutからのBloom時のみ発動（1st→1stでは発動しない）', async () => {
+    const e = await setupMainStep(deckMap, 182);
+    await e.registry.preload(['hBP03-038'], lib);
+    const p0 = e.state.players[0];
+    const fuwawa1 = [...lib.byNumber.values()].find((c) => c.name === 'フワワ・アビスガード' && c.bloomLevel === '1st');
+    if (fuwawa1) p0.deck.unshift(lib.getByNumber(fuwawa1.number));
+    const def = e.registry.get('hBP03-038');
+    const fromDebut = e._createHolomem(fakeHolomen({ name: 'モココ・アビスガード', bloomLevel: '1st' }), 1);
+    fromDebut.stack.push({ name: 'モココ・アビスガード', bloomLevel: 'Debut', kind: 'holomen' });
+    let r = def.bloomEffect.run(e._effectContext(0, { sourceHolomem: fromDebut })).next();
+    assertEq(r.value?.kind, 'chooseCard', 'DebutからのBloomでフワワ選択が出ない');
+    const from1st = e._createHolomem(fakeHolomen({ name: 'モココ・アビスガード', bloomLevel: '1st' }), 1);
+    from1st.stack.push({ name: 'モココ・アビスガード', bloomLevel: '1st', kind: 'holomen' });
+    r = def.bloomEffect.run(e._effectContext(0, { sourceHolomem: from1st })).next();
+    assert(r.done, '1st→1stのBloomで誤発動（DebutからBloom条件違反）');
+  });
+
+  await testAsync('hBP08-039 深淵からの信頼: 赤エールが青として数えられお休みフワワが起きる(hBP08-003連携)', async () => {
+    const e = await setupMainStep(deckMap, 183);
+    await e.registry.preload(['hBP08-039', 'hBP08-003'], lib);
+    const p0 = e.state.players[0];
+    p0.oshi = lib.getByNumber('hBP08-003'); // 〈フワワ/モココ〉の赤エールを青としても扱う
+    const mokoko = e._createHolomem(fakeHolomen({ name: 'モココ・アビスガード', bloomLevel: '2nd' }), 1);
+    for (let i = 0; i < 6; i++) mokoko.cheers.push({ number: 'r', name: '赤エール', kind: 'cheer', color: '赤' });
+    const fuwawaRest = e._createHolomem(fakeHolomen({ name: 'フワワ・アビスガード' }), 1);
+    fuwawaRest.rested = true;
+    p0.center = mokoko; p0.collab = null; p0.back = [fuwawaRest];
+    const def = e.registry.get('hBP08-039');
+    const gen = def.bloomEffect.run(e._effectContext(0, { sourceHolomem: mokoko }));
+    let r = gen.next();
+    assertEq(r.value?.kind, 'chooseHolomem', '赤6枚(青エイリアス)でお休みフワワを起こす選択が出ない');
+    const pick = r.value.buildOptions().find((o) => o.value);
+    r = gen.next(pick.value);
+    assertEq(fuwawaRest.rested, false, 'お休みフワワがアクティブになっていない');
+  });
+
   await testAsync('AI評価関数: ライフ差・盤面崩壊の符号が妥当', async () => {
     const e = await setupMainStep(deckMap, 160);
     const p0 = e.state.players[0]; const p1 = e.state.players[1];
@@ -1132,16 +1187,16 @@ export async function runTests() {
     const gen = def.collabEffect.run(e._effectContext(0, { sourceHolomem: kronii, sourceCard: kronii.stack[0] }));
     let r = gen.next();          // confirm
     assertEq(r.value.kind, 'confirm', 'confirm が出ていない');
-    r = gen.next(true);          // → chooseCard（付け替え可能なエール）
-    assertEq(r.value.kind, 'chooseCard', 'エール選択が出ていない');
-    const cheerNames = r.value.buildOptions().filter((o) => o.value).map((o) => o.value.name);
-    // クロニーのエールは送り先Y(≠自分・≠所有者クロニー・Promise)があるので候補。
-    // Yのエールは送り先が無い（他のPromiseはクロニー=自分のみ）ので候補外。
-    assert(cheerNames.includes('クロのエール'), 'クロニーのエールが付け替え候補に無い');
-    assert(!cheerNames.includes('Yのエール'), 'Yのエールが候補になっている（送り先が無いのに）');
-    // クロニーのエールを選ぶ → 付け替え先候補は Y のみ（自分・非Promise・所有者を除く）
-    const pick = r.value.buildOptions().find((o) => o.value && o.value.name === 'クロのエール');
-    r = gen.next(pick.value);
+    r = gen.next(true);          // → chooseHolomem（付け替え「元」のホロメン）
+    assertEq(r.value.kind, 'chooseHolomem', '元ホロメン選択が出ていない');
+    const fromNames = r.value.buildOptions().filter((o) => o.value).map((o) => o.value.top.name);
+    // クロニー（クロのエール／送り先Y=≠自分・≠所有者・Promiseあり）は元候補。
+    // Y（他のPromiseは自分クロニーのみ→送り先無し）は元候補外。
+    assert(fromNames.includes('オーロ・クロニー'), 'クロニーが付け替え元候補に無い');
+    assert(!fromNames.includes('Y'), 'Y が元候補になっている（送り先が無いのに）');
+    // クロニーを元に選ぶ → エールは1枚(クロのエール)なので自動 → 付け替え先候補は Y のみ
+    const fromPick = r.value.buildOptions().find((o) => o.value && o.value.top.name === 'オーロ・クロニー');
+    r = gen.next(fromPick.value);
     assertEq(r.value.kind, 'chooseHolomem', '付け替え先選択が出ていない');
     const destNames = r.value.buildOptions().filter((o) => o.value).map((o) => o.value.top.name);
     assertEq(destNames.join(','), 'Y', '付け替え先が Y のみになっていない（自分/非Promise/元の所有者が混入）');


### PR DESCRIPTION
…ル色判定)、hBP07-051付け替え元を盤面選択化、hBP08-104は実レベル上昇時のみドロー、hBP08-034出すDebutを選択可、hBP03-038はDebut元のみ発動、hBP08-039は赤→青エイリアスで青エール計上(ctx.cheerCountOfColor新設)。回帰テスト追加(102/102)