### PR TITLE
AI: 盤面エールを資源として評価(boardCheer=各ホロメンの最大アーツコスト数まで・余剰は無価値)。バトンコストで盤面エールを捨…

### DIFF
--- a/battle_simulator_v2/core/ai/evaluate.js
+++ b/battle_simulator_v2/core/ai/evaluate.js
@@ -26,6 +26,8 @@ export const WEIGHTS = {
   handCard: 4, // 手札1枚（リソース。中身は見ない＝枚数のみ）
   holoPower: 2, // ホロパワー1枚（推しスキルの燃料）
   archiveCheer: 1, // アーカイブのエール1枚（回収・再利用の見込み）
+  boardCheer: 4, // 盤上ホロメンに付いた「有用な」エール1枚（=将来使える最大アーツのコスト数まで。余剰は数えない）。
+  //               1ターン1枚しか増えない貴重な資源なので、バトンコスト等で捨てると明確な損になる（無駄打ち抑制）。
   lethalThreatToMe: -70, // 次の相手ターンに自センターが倒され得る
   lethalChanceToOpp: 55, // 自分が相手センターを倒し得る
   noBoard: -2000, // ステージにホロメンが居ない（実質敗北）
@@ -75,6 +77,21 @@ export function holomemBoardValue(engine, h, idx, attackSoon = true) {
   let v = hpRemain * WEIGHTS.hpRemain + threat * WEIGHTS.threat;
   if (payableDmg > 0 && attackSoon) v += WEIGHTS.ready; // 今すぐ攻撃に使える
   return v;
+}
+
+/**
+ * 盤上ホロメンに付いた「有用なエール」の総数。各ホロメンで「将来使える最大アーツ（現フォーム＋同名上位フォーム）の
+ * コスト枚数」を上限に数える＝アーツに必要な数までは資源として価値があるが、それを超えた余剰エールは無価値とみなす。
+ * これにより「コスト以上にエールを盛る無駄」を評価せず、「貯めたエールをバトンで捨てる損」を捉える。
+ */
+function usefulBoardCheers(engine, p) {
+  let n = 0;
+  for (const h of engine._stageHolomems(p)) {
+    const arts = [...(h.stack[0].arts || []), ...engine._higherFormArts(h.stack[0])];
+    const cap = Math.max(0, ...arts.map((a) => (a.cost || []).length));
+    n += Math.min((h.cheers || []).length, cap);
+  }
+  return n;
 }
 
 /** プレイヤー p（idx）の盤面総合力 */
@@ -228,6 +245,9 @@ export function evaluateState(engine, idx) {
   parts.holoPower = (me.holoPower.length - opp.holoPower.length) * WEIGHTS.holoPower;
   parts.archiveCheer = (me.archive.filter((c) => c.kind === 'cheer').length
     - opp.archive.filter((c) => c.kind === 'cheer').length) * WEIGHTS.archiveCheer;
+  // 盤上の「有用なエール」差（資源）。盤面に置いたエールはアーカイブの何倍も価値がある＝
+  // バトンコスト等で盤面→アーカイブへ捨てると net で損になる（=無駄なバトンを論理的に避ける）。
+  parts.boardCheer = (usefulBoardCheers(engine, me) - usefulBoardCheers(engine, opp)) * WEIGHTS.boardCheer;
 
   // 4) 盤面崩壊リスク（ホロメン不在＝実質敗北、センター空＝被弾しやすい）
   parts.structure = 0;

--- a/battle_simulator_v2/core/ai/score.js
+++ b/battle_simulator_v2/core/ai/score.js
@@ -378,6 +378,14 @@ function scoreMainActions(engine, idx, pending, out) {
           });
           if (!back.rested && backOff >= centerOff + 60 && !centerInvesting) score = 30;
         }
+        // バトンコストで捨てる「有用エール」のぶんを損として差し引く（貯めたエールの無駄捨てを論理的に抑制）。
+        if (score > 0) {
+          const cArts = p.center.stack[0].arts || [];
+          const cap = Math.max(0, ...cArts.map((a) => (a.cost || []).length));
+          const usefulOnCenter = Math.min((p.center.cheers || []).length, cap);
+          const batonCostLen = (p.center.stack[0].batonTouch || []).length;
+          score -= Math.min(batonCostLen, usefulOnCenter) * 8;
+        }
         break;
       }
       case 'oshiSkill': {

--- a/battle_simulator_v2/tests/test.js
+++ b/battle_simulator_v2/tests/test.js
@@ -2418,6 +2418,35 @@ export async function runTests() {
     assert(invested > empty, `大技に向けたエール投資が進んだ方を高く評価すべき (empty=${empty}, invested=${invested})`);
   });
 
+  await testAsync('AI評価: 盤面のエールをアーカイブへ捨てると評価が下がる（バトンコストの損を理解）', async () => {
+    const e = await setupMainStep(deckMap, 54);
+    const p0 = e.state.players[0];
+    const purple = () => ({ number: 'p', name: '紫', kind: 'cheer', color: '紫' });
+    const mk = { number: 'AZ', name: 'AZ', kind: 'holomen', bloomLevel: '2nd', hp: 200, color: '紫', tags: [],
+      arts: [{ name: 'big', dmg: 150, cost: ['紫', '紫', '紫'], tokkou: [] }], keywords: [] };
+    p0.center = e._createHolomem(mk, 0); p0.center.cheers = [purple(), purple(), purple()];
+    p0.collab = null; p0.back = []; p0.archive = [];
+    const before = evaluateState(e, 0).total;
+    // バトンコスト相当で盤面の紫3枚をアーカイブへ（資源を捨てた状態）
+    p0.center.cheers = []; p0.archive = [purple(), purple(), purple()];
+    const after = evaluateState(e, 0).total;
+    assert(before > after, `盤面エールをアーカイブへ捨てると評価が下がるべき (before=${before}, after=${after})`);
+  });
+
+  await testAsync('AI評価: アーツのコストを超える余剰エールは資源として価値が無い（必要数までのみ評価）', async () => {
+    const e = await setupMainStep(deckMap, 55);
+    const p0 = e.state.players[0];
+    const purple = () => ({ number: 'p', name: '紫', kind: 'cheer', color: '紫' });
+    const mk = { number: 'AZ2', name: 'AZ2', kind: 'holomen', bloomLevel: '2nd', hp: 200, color: '紫', tags: [],
+      arts: [{ name: 'a', dmg: 100, cost: ['紫', '紫', '紫'], tokkou: [] }], keywords: [] }; // コスト3
+    p0.collab = null; p0.back = []; p0.archive = [];
+    p0.center = e._createHolomem(mk, 0); p0.center.cheers = [purple(), purple(), purple()]; // ちょうど3
+    const exact = evaluateState(e, 0).total;
+    p0.center.cheers = [purple(), purple(), purple(), purple(), purple()]; // 余剰2枚
+    const excess = evaluateState(e, 0).total;
+    assert(excess === exact, `コスト超過の余剰エールは評価に影響しないべき (exact=${exact}, excess=${excess})`);
+  });
+
   await testAsync('深い先読み(2手/3手): クラッシュせず対戦が完了し、合法手を返す', async () => {
     const r = await fetch('../test_deck/' + encodeURIComponent('FUWAMOCO') + '.json'); const dm = await r.json();
     const reg = await buildRegistry(lib, dm);


### PR DESCRIPTION
…てる損を評価が理解し無駄バトンを論理的に抑制、余剰エール付けも無価値化。バトン採点にも捨てエール減点を追加。回帰143/143