### PR TITLE
CPU改善: ①使い切れる上限(現+ブルーム後アーツのコスト)超の無益なエール過剰付与を強く禁止(メリットある余剰=火力増は許可)。②③純…

### DIFF
--- a/battle_simulator_v2.html
+++ b/battle_simulator_v2.html
@@ -29,7 +29,7 @@
       <button id="start-button">ゲーム開始</button>
       <div id="setup-error"></div>
       <!-- 更新確認用バージョン（コミット時に日時を更新）。ハードリロードで反映されたかの目印 -->
-      <div id="app-version">2026-06-26 06:27</div>
+      <div id="app-version">2026-06-26 06:57</div>
     </div>
 
     <!-- ゲーム画面 -->

--- a/battle_simulator_v2/core/ai/lookahead.js
+++ b/battle_simulator_v2/core/ai/lookahead.js
@@ -25,7 +25,7 @@
 import { HeuristicAI } from './heuristic.js';
 import { evaluateState } from './evaluate.js';
 import { reconstruct } from './rollout.js';
-import { scoreOptions, bestOptionId, isDevelopSupport } from './score.js';
+import { scoreOptions, bestOptionId, isDevelopSupport, isFreePlaySupport } from './score.js';
 import { createRng } from '../rng.js';
 
 // ロールアウト評価が「ほぼ互角」とみなす差（この範囲内の候補は、ヒューリスティック事前評価で優劣を割る）。
@@ -67,6 +67,20 @@ export class LookaheadAI {
     // ※ドロー/サーチ主体の支援は「デッキ切れの綱引き」があるため貪欲にせず先読みの判断に委ねる。
     if (pending.type === 'main') {
       const me = s.players[this.playerIdx];
+      // #2/#3: 純粋なドロー/サーチ支援(のどか等=メリットしかない)は「先に」使って手札・情報を増やす（選択肢を増やしてから戦術判断）。
+      // ただし守るべき制約: (a) 山が薄い時(<=8)は引き過ぎ＝デッキ切れを避けるため強制せず先読みに委ねる。
+      //   (b) LIMITEDは1ターン1枚。タイミングが重要なLIMITED(じゃあ敵だね等=フリープレイでないLIMITED)が手札にある時は、
+      //       その枠を貪欲に消費しない（使い時を先読みに委ねる）。＝純粋ドローでも枠を奪わない。
+      const hasTacticalLimited = cands.some((o) => o.kind === 'support' && me.hand[o.handIndex]?.limited
+        && !isFreePlaySupport(engine, me.hand[o.handIndex]));
+      const freeDraw = cands.find((o) => {
+        if (o.kind !== 'support') return false;
+        const c = me.hand[o.handIndex];
+        if (!c || !isFreePlaySupport(engine, c)) return false;
+        if (c.limited && hasTacticalLimited) return false; // LIMITED枠の取り合いは先読みに委ねる
+        return true;
+      });
+      if (freeDraw && me.deck.length > 8) return freeDraw.id;
       // 発展支援(ふつうのパソコン等)を place より先に（盤面が埋まって canUse を満たせなくなる前に使う）。
       const devSup = cands.find((o) => o.kind === 'support' && me.hand[o.handIndex] && isDevelopSupport(engine, me.hand[o.handIndex]));
       if (devSup) return devSup.id;

--- a/battle_simulator_v2/core/ai/score.js
+++ b/battle_simulator_v2/core/ai/score.js
@@ -225,7 +225,10 @@ function scoreCheerTargets(engine, idx, pending, out) {
     let score = 0;
     if (arts.length > 0 && cheer) {
       const afterCheers = [...h.cheers, cheer];
-      const maxCost = Math.max(...arts.map((a) => a.cost.length));
+      // 使い切れるエール上限(cap)＝現フォーム＋同名ブルーム後フォームのアーツの最大コスト枚数。
+      // これを超えるエールは（火力が伸びる/色が前進する等のメリットが無い限り）純粋な過剰付与。
+      const allArts = [...arts, ...engine._higherFormArts(h.stack[0])];
+      const cap = Math.max(0, ...allArts.map((a) => (a.cost || []).length));
       let useful = false;
       // 実効火力の伸び（解放＋枚数依存スケールを一般的に捕捉。カード番号は見ない）
       const dmgNow = bestEffDmg(h, h.cheers);
@@ -247,8 +250,13 @@ function scoreCheerTargets(engine, idx, pending, out) {
           if (unmetCost(afterCheers, a.cost) < unmetCost(h.cheers, a.cost)) { advanced = true; break; }
         }
         if (advanced) { useful = true; score += isActive ? 12 : 5; }
-        else if (h.cheers.length >= maxCost) score -= 30; // どのアーツも伸びず満杯＝過剰投資
-        else score += 2; // 色が噛み合わず前進しない（最小限）
+        else if (h.cheers.length >= cap) {
+          // 過剰付与の禁止: 使い切れる上限(cap)に達した体へ、火力も伸びず色も前進しないエールを足すのは無意味＝強く禁止。
+          // 超過枚数が増えるほど重く罰し、別の体（空きのある前衛/バック）へ回させる。「効果としてメリットがある」場合は
+          // gain>0 や advanced 側に入るのでここには来ない（＝メリットがある余剰だけが許される）。
+          score -= 100 + (h.cheers.length - cap) * 20;
+        }
+        else score += 2 - h.cheers.length * 0.3; // 色が噛み合わず前進しない（最小限。空いてる体を優先＝散らす）
       }
       // 位置ボーナスは「有用なエール」のときだけ＝攻撃できる前衛に集中。無駄な色を位置目的で前衛に置かない。
       if (useful) {


### PR DESCRIPTION
…粋ドロー/サーチ(のどか等)を盤面処理より先に貪欲使用(山薄い時/タイミング重要LIMITEDがある時は先読みに委ねる)。自己対戦でデッキ切れ抑制・勝率4-4・無駄バトン低位維持。回帰151/151。build 2026-06-26 06:57