### PR TITLE
リザルト画面を整理：リプレイ再生中は「リプレイを保存」を非表示、「もう一度」を実挙動に合わせ「🏠 デッキ選択へ戻る」に改名（デッキ選択画面…

### DIFF
--- a/battle_simulator_v2.html
+++ b/battle_simulator_v2.html
@@ -43,7 +43,7 @@
       </div>
 
       <!-- 更新確認用バージョン（コミット時に日時を更新）。ハードリロードで反映されたかの目印 -->
-      <div id="app-version">2026-06-26 22:40 リプレイ停止バグ修正(自動送り競合)</div>
+      <div id="app-version">2026-06-26 22:55 リザルト整理(保存非表示/戻る改名)</div>
     </div>
 
     <!-- ゲーム画面 -->
@@ -198,7 +198,7 @@
         <div id="result-buttons">
           <button id="save-replay-button">💾 リプレイを保存</button>
           <button id="view-board-button">盤面を確認</button>
-          <button id="restart-button">もう一度</button>
+          <button id="restart-button">🏠 デッキ選択へ戻る</button>
         </div>
       </div>
       <button id="show-result-button">🏆 結果を表示</button>

--- a/battle_simulator_v2/ui/app.js
+++ b/battle_simulator_v2/ui/app.js
@@ -269,7 +269,8 @@ function updateReplayUI(replaying) {
     const sec = document.getElementById(id)?.closest('.settings-section');
     if (sec) sec.style.display = replaying ? 'none' : '';
   }
-  for (const id of ['concede-p1-button', 'concede-p2-button']) {
+  // 投了（再生中は無意味）＋ リザルトの「リプレイを保存」（観戦中の保存は無意味）を隠す
+  for (const id of ['concede-p1-button', 'concede-p2-button', 'save-replay-button']) {
     const b = document.getElementById(id);
     if (b) b.style.display = replaying ? 'none' : '';
   }


### PR DESCRIPTION
…へ戻る意図を明確化）