### PR TITLE
スマホ手札の横スクロール改善：手札カードを touch-action:pan-x にし横スワイプをブラウザのスクロールへ委譲（縦ドラッグの…

### DIFF
--- a/battle_simulator_v2/css/board.css
+++ b/battle_simulator_v2/css/board.css
@@ -461,6 +461,10 @@ body.dragging, body.dragging * { cursor: grabbing !important; }
 /* 手札: カード本体（ヒット判定）は動かさず、絵柄(img)だけ持ち上げる
    （カードごと動かすとカーソル下から逃げて hover が点滅するため） */
 #hand .card { width: 104px; height: 145px; background: transparent; border: none; }
+/* スマホ: 手札カードは横スワイプを「ブラウザの横スクロール」に渡し、
+   縦方向のドラッグだけを自前のカードプレイ判定に使う（上方向へドラッグ＝場に出す）。
+   .can-drag の touch-action:none をこの specificity で上書きする。 */
+#hand .card.can-drag { touch-action: pan-x; }
 #hand .card img { transition: transform 0.15s ease; }
 #hand .card:hover img { transform: translateY(-26px) scale(1.12); }
 #hand .card::after { display: none; }

--- a/battle_simulator_v2/ui/app.js
+++ b/battle_simulator_v2/ui/app.js
@@ -593,6 +593,11 @@ function setupDnDListeners() {
       const dx = e.clientX - dragState.startX;
       const dy = e.clientY - dragState.startY;
       if (dx * dx + dy * dy < 36) return; // 6px動くまではクリック扱い
+      // タッチの手札カードは、横優位のスワイプをドラッグにせずブラウザの横スクロール
+      // に委ねる（手札の play は上方向ドラッグ。pointercancel 取りこぼし対策）。
+      // 盤面の駒（touch-action:none で横スクロールが無い）は全方向ドラッグのまま。
+      if (e.pointerType === 'touch' && dragState.src.includes(':hand:')
+          && Math.abs(dx) > Math.abs(dy)) return;
       startDrag(e);
     } else {
       moveDrag(e);
@@ -608,6 +613,15 @@ function setupDnDListeners() {
       dragEndedAt = Date.now();
       endDrag(st, e);
     }
+  });
+
+  // スマホで手札を横スワイプすると、ブラウザが横スクロールのためにポインタを
+  // 奪い pointercancel を送ってくる（touch-action: pan-x）。掴みかけの状態を破棄する。
+  document.addEventListener('pointercancel', () => {
+    if (!dragState) return;
+    const st = dragState;
+    dragState = null;
+    if (st.started) cleanupDrag(st);
   });
 
   // ドラッグ直後の click はインスペクタ等を開かない（capture で握りつぶす）


### PR DESCRIPTION
…みカードプレイ）。pointercancel でドラッグ破棄＋タッチ手札は縦優位時のみ掴む